### PR TITLE
add make image script

### DIFF
--- a/0.X/Dockerfile
+++ b/0.X/Dockerfile
@@ -1,11 +1,6 @@
 FROM alpine:3.12
-LABEL org.opencontainers.image.authors="Consul Team <consul@hashicorp.com>"
 
-# This is the release of Consul to pull in.
-ENV CONSUL_VERSION=1.8.3
-
-# This is the location of the releases.
-ENV HASHICORP_RELEASES=https://releases.hashicorp.com
+COPY consul /bin/consul
 
 # Create a consul user and group first so the IDs get set the same way, even as
 # the rest of this may change over time.
@@ -16,29 +11,7 @@ RUN addgroup consul && \
 # libc6-compat is needed to symlink the shared libraries for ARM builds
 RUN set -eux && \
     apk add --no-cache ca-certificates curl dumb-init gnupg libcap openssl su-exec iputils jq libc6-compat && \
-    gpg --keyserver pgp.mit.edu --recv-keys 91A6E7F85D05C65630BEF18951852D87348FFC4C && \
-    mkdir -p /tmp/build && \
-    cd /tmp/build && \
-    apkArch="$(apk --print-arch)" && \
-    case "${apkArch}" in \
-        aarch64) consulArch='arm64' ;; \
-        armhf) consulArch='armhfv6' ;; \
-        x86) consulArch='386' ;; \
-        x86_64) consulArch='amd64' ;; \
-        *) echo >&2 "error: unsupported architecture: ${apkArch} (see ${HASHICORP_RELEASES}/consul/${CONSUL_VERSION}/)" && exit 1 ;; \
-    esac && \
-    wget ${HASHICORP_RELEASES}/consul/${CONSUL_VERSION}/consul_${CONSUL_VERSION}_linux_${consulArch}.zip && \
-    wget ${HASHICORP_RELEASES}/consul/${CONSUL_VERSION}/consul_${CONSUL_VERSION}_SHA256SUMS && \
-    wget ${HASHICORP_RELEASES}/consul/${CONSUL_VERSION}/consul_${CONSUL_VERSION}_SHA256SUMS.sig && \
-    gpg --batch --verify consul_${CONSUL_VERSION}_SHA256SUMS.sig consul_${CONSUL_VERSION}_SHA256SUMS && \
-    grep consul_${CONSUL_VERSION}_linux_${consulArch}.zip consul_${CONSUL_VERSION}_SHA256SUMS | sha256sum -c && \
-    unzip -d /bin consul_${CONSUL_VERSION}_linux_${consulArch}.zip && \
-    cd /tmp && \
-    rm -rf /tmp/build && \
-    gpgconf --kill all && \
-    apk del gnupg openssl && \
-    rm -rf /root/.gnupg && \
-# tiny smoke test to ensure the binary we downloaded runs
+    # tiny smoke test to ensure the binary we downloaded runs
     consul version
 
 # The /consul/data dir is used by Consul to store state. The agent will be started

--- a/0.X/make-image.sh
+++ b/0.X/make-image.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+SCRIPT_NAME="$(basename ${BASH_SOURCE[0]})"
+pushd $(dirname ${BASH_SOURCE[0]}) > /dev/null
+SCRIPT_DIR=$(pwd)
+
+function usage {
+cat <<-EOF
+Usage: ${SCRIPT_NAME}  <consul source directory>
+
+Description:
+   
+    This script will build a docker container with a build from the consul source code directory provided.
+EOF
+}
+
+function err {
+    tput bold
+    tput setaf 1
+
+    echo "$@" 1>&2
+
+    tput sgr0
+}
+
+if test -z "$1"
+then
+    err "$(usage)"
+    exit 1
+fi
+
+function main {
+    declare sdir="$1"
+
+    ${sdir}/build-support/scripts/dibs-build.sh
+
+    if test $? -ne 0
+    then
+        err "error building consul"
+        exit 1
+    fi
+
+    cp ${sdir}/pkg/bin/linux_amd64/consul ${SCRIPT_DIR}/
+
+    docker build --no-cache -t dibs-consul ${SCRIPT_DIR}
+
+    rm -rf ${SCRIPT_DIR}/consul
+
+    return $?
+}
+
+main "$@"
+exit $?


### PR DESCRIPTION
I removed the signing stuff and the remote fetching of executables. The make-image.sh script will build the proper executable using the build script I made in the source repo, and then put that executable in a container called dibs-consul.